### PR TITLE
Differentiate authorization for manager and employees within admin view

### DIFF
--- a/ReservationSystem/Areas/Admin/Controllers/HomeController.cs
+++ b/ReservationSystem/Areas/Admin/Controllers/HomeController.cs
@@ -10,10 +10,9 @@ using ReservationSystem.Services;
 namespace ReservationSystem.Areas.Admin.Controllers
 {
     [Area("Admin")]
-    [Authorize(Roles = "Admin")]
+    [Authorize(Roles = "Employee, Manager")]
     public class HomeController : Controller
     {
-
         private readonly ApplicationDbContext _context;
         private readonly PersonService _personService;
 
@@ -27,7 +26,5 @@ namespace ReservationSystem.Areas.Admin.Controllers
         {
             return View();
         }
-
-
     }
 }

--- a/ReservationSystem/Areas/Admin/Controllers/ReservationController.cs
+++ b/ReservationSystem/Areas/Admin/Controllers/ReservationController.cs
@@ -11,10 +11,9 @@ using ReservationSystem.Services;
 namespace ReservationSystem.Areas.Admin.Controllers
 {
     [Area("Admin")]
-    [Authorize(Roles = "Admin")]
+    [Authorize(Roles = "Employee, Manager")]
     public class ReservationController : Controller
     {
-
         private readonly ApplicationDbContext _context;
         private readonly PersonService _personService;
 
@@ -45,6 +44,7 @@ namespace ReservationSystem.Areas.Admin.Controllers
             return View(m);
         }
 
+        [Authorize(Roles="Manager")]
         [HttpGet]
         public async Task<IActionResult> Create(int? sittingId)
         {
@@ -72,6 +72,7 @@ namespace ReservationSystem.Areas.Admin.Controllers
             return View(reservation);
         }
 
+        [Authorize(Roles="Manager")]
         [HttpPost]
         public async Task<IActionResult> Create(Models.Reservation.Create m)
         {
@@ -191,9 +192,5 @@ namespace ReservationSystem.Areas.Admin.Controllers
             return View(m);
 
         }
-
-
-
-
     }
 }

--- a/ReservationSystem/Areas/Admin/Controllers/SittingController.cs
+++ b/ReservationSystem/Areas/Admin/Controllers/SittingController.cs
@@ -8,7 +8,7 @@ using ReservationSystem.Data;
 namespace ReservationSystem.Areas.Admin.Controllers
 {
     [Area("Admin")]
-    [Authorize(Roles = "Admin")]
+    [Authorize(Roles="Employee, Manager")]
     public class SittingController : Controller
     {
         private readonly ApplicationDbContext _context;
@@ -72,7 +72,7 @@ namespace ReservationSystem.Areas.Admin.Controllers
             return View(sittingVM);
         }
 
-
+        [Authorize(Roles="Manager")]
         [HttpGet]
         public async Task<IActionResult> Create()
         {
@@ -94,6 +94,7 @@ namespace ReservationSystem.Areas.Admin.Controllers
             return View(sitting);
         }
 
+        [Authorize(Roles = "Manager")]
         [HttpPost]
         public async Task<IActionResult> Create(Models.Sitting.Create m)
         {
@@ -119,6 +120,7 @@ namespace ReservationSystem.Areas.Admin.Controllers
             return RedirectToAction("Index");
         }
 
+        [Authorize(Roles = "Manager")]
         [HttpGet]
         public async Task<IActionResult> Edit(int sittingId)
         {
@@ -155,6 +157,7 @@ namespace ReservationSystem.Areas.Admin.Controllers
             }
         }
 
+        [Authorize(Roles = "Manager")]
         [HttpPost]
         public async Task<IActionResult> Edit(Areas.Admin.Models.Sitting.Edit m)
         {

--- a/ReservationSystem/Areas/Admin/Views/Home/Index.cshtml
+++ b/ReservationSystem/Areas/Admin/Views/Home/Index.cshtml
@@ -6,8 +6,10 @@
 
 <h1>Admin Home</h1>
 
-<a type="button" class="btn btn-primary" asp-controller="Sitting" asp-action="Create">Add Sitting</a>
-<br/>
+@if(User.IsInRole("Manager")){
+    <a type="button" class="btn btn-primary" asp-controller="Sitting" asp-action="Create">Add Sitting</a>
+    <br/>
+}
 <a type="button" class="btn btn-primary" asp-controller="Sitting" asp-action="Index">View Sittings</a>
 <br/>
 <a type="button" class="btn btn-primary" asp-controller="Reservation" asp-action="Index">View Reservations</a>

--- a/ReservationSystem/Areas/Admin/Views/Sitting/Index.cshtml
+++ b/ReservationSystem/Areas/Admin/Views/Sitting/Index.cshtml
@@ -17,8 +17,10 @@
 				<th> Title </th>
 				<th> PercentFull </th>
 				<th> View Sitting Details </th>
-				<th> Edit Sitting Details </th>
-				<th> Close Reservation </th>
+				@if(User.IsInRole("Manager")){
+					<th> Edit Sitting Details </th>
+					<th> Close Sitting </th>
+				}
 			</tr>
 		</thead>
 		<tbody>
@@ -33,12 +35,15 @@
 					<td>
 						<button type="button" class="btn btn-primary" onclick="location.href = '@Url.Action("Details", "Sitting", new {sittingId = r.SittingID})'">View Details</button>
 					</td>
-					<td>
-						<button type="button" class="btn btn-primary" onclick="location.href = '@Url.Action("Edit", "Sitting", new {sittingId = r.SittingID})'">Edit Details</button>
-					</td>
-					<td>
-						<button type="button" class="btn btn-primary">Close Sitting</button>
-					</td>
+					@if (User.IsInRole("Manager"))
+					{
+						<td>
+							<button type="button" class="btn btn-primary" onclick="location.href = '@Url.Action("Edit", "Sitting", new {sittingId = r.SittingID})'">Edit Details</button>
+						</td>
+						<td>
+							<button type="button" class="btn btn-primary">Close Sitting</button>
+						</td>						
+					}
 				</tr>
 			}
 		</tbody>

--- a/ReservationSystem/Data/Utilities/IdentitySeed.cs
+++ b/ReservationSystem/Data/Utilities/IdentitySeed.cs
@@ -20,29 +20,57 @@ namespace ReservationSystem.Data.Utilities
             _passwordHasher = new PasswordHasher<IdentityUser>(); 
             _personService = personService;
         }
-        public async Task SeedAdmin()
+        public async Task SeedManager()
         {
             var user = new IdentityUser
             {
-                UserName = "admin@admin.com",
-                NormalizedUserName = "ADMIN@ADMIN.COM",
-                Email = "admin@admin.com",
-                NormalizedEmail = "ADMIN@ADMIN.COM",
+                UserName = "manager@manager.com",
+                NormalizedUserName = "MANAGER@MANAGER.COM",
+                Email = "manager@manager.com",
+                NormalizedEmail = "MANAGER@MANAGER.COM",
                 EmailConfirmed = true,
                 LockoutEnabled = false,
                 SecurityStamp = Guid.NewGuid().ToString()
             };
 
-            if (!_context.Roles.Any(r => r.Name == "Admin"))
+            if (!_context.Roles.Any(r => r.Name == "Manager"))
             {
-                await _roleStore.CreateAsync(new IdentityRole { Name = "Admin", NormalizedName = "ADMIN" });
+                await _roleStore.CreateAsync(new IdentityRole { Name = "Manager", NormalizedName = "MANAGER" });
             }
 
             if (!_context.Users.Any(u => u.UserName == user.UserName))
             {
-                user.PasswordHash = _passwordHasher.HashPassword(user, "admin");
+                user.PasswordHash = _passwordHasher.HashPassword(user, "manager");
                 await _userStore.CreateAsync(user);
-                await _userStore.AddToRoleAsync(user, "Admin");
+                await _userStore.AddToRoleAsync(user, "Manager");
+            }
+
+            await _context.SaveChangesAsync();
+        }
+
+        public async Task SeedEmployee()
+        {
+            var user = new IdentityUser
+            {
+                UserName = "employee@employee.com",
+                NormalizedUserName = "EMPLOYEE@EMPLOYEE.COM",
+                Email = "employee@employee.com",
+                NormalizedEmail = "EMPLOYEE@EMPLOYEE.COM",
+                EmailConfirmed = true,
+                LockoutEnabled = false,
+                SecurityStamp = Guid.NewGuid().ToString()
+            };
+
+            if (!_context.Roles.Any(r => r.Name == "Employee"))
+            {
+                await _roleStore.CreateAsync(new IdentityRole { Name = "Employee", NormalizedName = "EMPLOYEE" });
+            }
+
+            if (!_context.Users.Any(u => u.UserName == user.UserName))
+            {
+                user.PasswordHash = _passwordHasher.HashPassword(user, "employee");
+                await _userStore.CreateAsync(user);
+                await _userStore.AddToRoleAsync(user, "Employee");
             }
 
             await _context.SaveChangesAsync();

--- a/ReservationSystem/Program.cs
+++ b/ReservationSystem/Program.cs
@@ -65,7 +65,8 @@ app.MapRazorPages();
 using (var scope = app.Services.CreateScope())
 {
     var identitySeedService = scope.ServiceProvider.GetService<IdentitySeed>();
-    await identitySeedService.SeedAdmin();
+    await identitySeedService.SeedManager();
+    await identitySeedService.SeedEmployee();
     await identitySeedService.SeedMember();
 
     var sqlService = scope.ServiceProvider.GetService<SeedSQL>();

--- a/ReservationSystem/ReservationSystem.csproj
+++ b/ReservationSystem/ReservationSystem.csproj
@@ -27,6 +27,7 @@
 	<ItemGroup>
 		<Folder Include="Areas\Admin\Data\" />
 		<Folder Include="Areas\Member\Models\" />
+		<Folder Include="Migrations\" />
 	</ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
- Replaced data seeding for "admin" with "manager" and "employee".
- Employee is restricted from accessing and viewing actions that they do not have the authority for within the admin view.